### PR TITLE
use node labels.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/node": "^16.11.47",
         "@types/react": "^18.0.15",
         "@types/react-dom": "^18.0.6",
-        "behave-graph": "^0.9.6",
+        "behave-graph": "^0.9.9",
         "classnames": "^2.3.1",
         "downshift": "^6.1.7",
         "react": "^18.2.0",
@@ -5058,9 +5058,9 @@
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="
     },
     "node_modules/behave-graph": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/behave-graph/-/behave-graph-0.9.6.tgz",
-      "integrity": "sha512-DKNUTeHVTUgmjlxq7+Mq3UHnVJnLbBFxh4p3Qj25GorHYn0XEDEGGZkfA+u5rd44yC1UnWproHvkyd+38ulEkg=="
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/behave-graph/-/behave-graph-0.9.9.tgz",
+      "integrity": "sha512-G1oz//djiZJhu2geo4CJGR6dIPsj1nBf7N/9KLTqztZRX7hAVTikPQORpgaCAY2R9JNk7s+Rq1g/FiOBgP7diA=="
     },
     "node_modules/bfj": {
       "version": "7.0.2",
@@ -19423,9 +19423,9 @@
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="
     },
     "behave-graph": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/behave-graph/-/behave-graph-0.9.6.tgz",
-      "integrity": "sha512-DKNUTeHVTUgmjlxq7+Mq3UHnVJnLbBFxh4p3Qj25GorHYn0XEDEGGZkfA+u5rd44yC1UnWproHvkyd+38ulEkg=="
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/behave-graph/-/behave-graph-0.9.9.tgz",
+      "integrity": "sha512-G1oz//djiZJhu2geo4CJGR6dIPsj1nBf7N/9KLTqztZRX7hAVTikPQORpgaCAY2R9JNk7s+Rq1g/FiOBgP7diA=="
     },
     "bfj": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@types/node": "^16.11.47",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
-    "behave-graph": "^0.9.6",
+    "behave-graph": "^0.9.9",
     "classnames": "^2.3.1",
     "downshift": "^6.1.7",
     "react": "^18.2.0",

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -10,13 +10,6 @@ type NodeProps = FlowNodeProps & {
   spec: NodeSpecJSON;
 };
 
-const getTitle = (type: string) => {
-  const tokens = type.split("/");
-  const end = tokens[Math.min(tokens.length - 1, 1)]; // handles polymorphic node naming structure
-  const spaces = end.replace(/([A-Z])/g, " $1");
-  return spaces.charAt(0).toUpperCase() + spaces.slice(1);
-};
-
 const getPairs = <T, U>(arr1: T[], arr2: U[]) => {
   const max = Math.max(arr1.length, arr2.length);
   const pairs = [];
@@ -33,7 +26,7 @@ export const Node = ({ id, data, spec, selected }: NodeProps) => {
   const pairs = getPairs(spec.inputs, spec.outputs);
   return (
     <NodeContainer
-      title={getTitle(spec.type)}
+      title={spec.label}
       category={spec.category}
       selected={selected}
     >


### PR DESCRIPTION
This builds upon the previous PR to use the new node labels from the node spec.  Thus we no longer have to try to parse out the formal node name into a usable label.